### PR TITLE
Added a function to setCurrentSlideByIndex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,12 @@ class Slider extends React.PureComponent {
 		this.goTo(nextSlideIndex, NEXT);
 	};
 
+	setCurrentSlideByIndex = (index) => {
+		this.setState({
+			currentSlideIndex: index
+		});
+	}
+
 	getSlideClass = (index) => {
 		const {
 			currentSlideIndex,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -92,6 +92,16 @@ test('animate previous classNames', () => {
 	expect(animatedSnapshot).not.toEqual(initialSnapshot);
 });
 
+test('setCurrentSlideByIndex changes current Slide', () => {
+	const slider = ReactTestRenderer.create(<Slider><div>First Slide</div><div>Second Slide</div><div>Third Slide</div><div>Fourth Slide</div></Slider>);
+	expect(slider.root.findByProps({className: "slide current"}).children).toEqual(['First Slide']);
+	slider.getInstance().setCurrentSlideByIndex(1);
+	expect(slider.root.findByProps({className: "slide current"}).children).toEqual(['Second Slide']);
+	expect(slider.root.findByProps({className: "slide previous"}).children).toEqual(['First Slide']);
+	expect(slider.root.findByProps({className: "slide next"}).children).toEqual(['Third Slide']);
+	expect(slider.root.findByProps({className: "slide hidden"}).children).toEqual(['Fourth Slide']);
+});
+
 test('does not allow navigation while animating', () => {
 	const slider = ReactTestRenderer.create(<Slider><div /><div /><div /></Slider>);
 	slider.getInstance().next();


### PR DESCRIPTION
Added a function to `setCurrentSlideByIndex` that could be exposed via refs to allow other components on the page to help control the slider. Also added the relevant test.

I wanted a way to control the component via menu buttons on the page. Since the framework to properly set the `currentSliderIndex` already existed, I was able to simply add a new function `setCurrentSlideByIndex` (happy to use shorter name if preferred) that set the new state appropriately. Added test to show that all slides end up with the appropriate css classes. I also tested the full solution locally as well.