### PR TITLE
feature: add typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "react-animated-slider",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Animated slider component for react",
   "main": "build/index.js",
+  "typings": "build/index.d.ts",
   "files": [
     "build"
   ],
@@ -58,6 +59,7 @@
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "clean-webpack-plugin": "^3.0.0",
+    "copy-webpack-plugin": "^5.1.0",
     "css-hot-loader": "^1.4.4",
     "css-loader": "^3.2.0",
     "eslint": "^6.7.1",
@@ -77,6 +79,7 @@
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-test-renderer": "^16.4.0",
+    "typescript": "3.7.3",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.9.0"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,37 @@
+interface ISliderProps {
+  children: React.ReactElement[];
+  slideIndex?: number;
+  duration?: number;
+  disabled?: boolean;
+  infinite?: boolean;
+  autoplay?: number;
+  touchDisabled?: boolean;
+  minSwipeOffset?: number;
+  previousButton?: React.ReactElement;
+  nextButton?: React.ReactElement;
+  classNames?: IClassNames;
+}
+
+interface IClassNames {
+  slider?: string;
+  previousButton?: string;
+  nextButton?: string;
+  buttonDisabled?: string;
+  track?: string;
+  slide?: string;
+  hidden?: string;
+  previous?: string;
+  next?: string;
+  animateIn?: string;
+  animateOut?: string;
+}
+
+declare module "react-animated-slider" {
+  import React from "react";
+
+  class Slider extends React.Component<
+    ISliderProps & JSX.IntrinsicElements["div"]
+  > {}
+
+  export = Slider;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const IgnoreEmitPlugin = require('ignore-emit-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 
 const sliderConfig = {
 	entry: {
@@ -47,7 +48,8 @@ const sliderConfig = {
 		new MiniCssExtractPlugin({
 			filename: '[name].css',
 			chunkFilename: '[name].css',
-		}),
+    }),
+    new CopyPlugin([{ from: './src/index.d.ts', to: './index.d.ts' }])
 	],
 };
 


### PR DESCRIPTION
Changes:
* added typescript declaration file containting typings `Slider` component
* change in webpack build process - added copy-webpack-plugin in order to copy declaration files to `build` directory,
* bumped library version to 2.1.0

I recommend using Prettier for this project. I had difficulties to format `webpack.config.js` file, didn't know if I should use tabs with width 8 or 7 or 6. I decided to format this with my default settings. Please tell me how I can correct this.